### PR TITLE
Remove SciPy

### DIFF
--- a/stagesb/00-sbot/00-packages
+++ b/stagesb/00-sbot/00-packages
@@ -1,2 +1,1 @@
 python3-pip
-gfortran

--- a/stagesb/00-sbot/01-run-chroot.sh
+++ b/stagesb/00-sbot/01-run-chroot.sh
@@ -1,3 +1,3 @@
 apt install -y libatlas-base-dev
 
-pip3 install sbot numpy scipy
+pip3 install sbot numpy


### PR DESCRIPTION
Something in SciPy changed upstream and we were compiling it in the build process. Let's not.